### PR TITLE
Update tutorial documentation

### DIFF
--- a/site/jekyll/tutorials/aspnet4.md
+++ b/site/jekyll/tutorials/aspnet4.md
@@ -45,6 +45,36 @@ We need to install ReactJS.NET to the newly-created project. This is accomplishe
 
 <img src="/img/tutorial/nuget.png" alt="Screenshot: Install NuGet Packages" width="650" />
 
+You will also need to install a JS engine to use (either V8 or ChakraCore are recommended). See the [JSEngineSwitcher docs](https://github.com/Taritsyn/JavaScriptEngineSwitcher/wiki/Registration-of-JS-engines) for more information.
+
+To use V8, add the following packages:
+
+```
+JavaScriptEngineSwitcher.V8
+JavaScriptEngineSwitcher.V8.Native.win-x64
+```
+
+`ReactConfig.cs` will be automatically generated for you. Update it to register a JS engine:
+
+```csharp
+using JavaScriptEngineSwitcher.Core;
+using JavaScriptEngineSwitcher.V8;
+
+[assembly: WebActivatorEx.PreApplicationStartMethod(typeof(React.Sample.Mvc4.ReactConfig), "Configure")]
+
+namespace React.Sample.Mvc4
+{
+	public static class ReactConfig
+	{
+		public static void Configure()
+		{
+			JsEngineSwitcher.Current.DefaultEngineName = V8JsEngine.EngineName;
+			JsEngineSwitcher.Current.EngineFactories.AddV8();
+		}
+	}
+}
+```
+
 ### Create basic controller and view
 
 Since this tutorial focuses mainly on ReactJS.NET itself, we will not cover creation of an MVC controller in much detail. To learn more about ASP.NET MVC, refer to [its official website](https://www.asp.net/mvc).

--- a/site/jekyll/tutorials/aspnetcore.md
+++ b/site/jekyll/tutorials/aspnetcore.md
@@ -66,6 +66,8 @@ At the top of the file, add:
 
 ```csharp
 using Microsoft.AspNetCore.Http;
+using JavaScriptEngineSwitcher.Core;
+using JavaScriptEngineSwitcher.ChakraCore;
 using React.AspNet;
 ```
 
@@ -81,6 +83,10 @@ Add:
 ```csharp
 services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 services.AddReact();
+
+// Make sure a JS engine is registered, or you will get an error!
+services.AddJsEngineSwitcher(options => options.DefaultEngineName = ChakraCoreJsEngine.EngineName)
+  .AddChakraCore();
 ```
 
 Directly **above**:


### PR DESCRIPTION
Add a reference to installing a specific Javascript engine, which was only present in the getting started docs.

Fixes #645